### PR TITLE
Add role-agent matrix and role-based dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,3 +219,14 @@ Audit Logs: Every update stored with timestamps/user
 
 No API keys or 3rd-party model calls required
 
+
+## Role to Agent Matrix
+
+| Role | Key Agents & Features |
+| --- | --- |
+| Super Admin | Dashboard Agent for monitoring, Demand Forecast Agent for planning, Inventory Optimization Agent, Logistics Routing Agent, Invoice Reconciliation Agent, Chatbot Agent |
+| Manufacturer | Demand Forecast Agent for production planning, Logistics Routing Agent for dispatch, Invoice Reconciliation Agent, Chatbot Agent |
+| CFA | Inventory Optimization Agent, Logistics Routing Agent, Invoice Reconciliation Agent, Chatbot Agent |
+| Super Stockist | Demand Forecast Agent, Inventory Optimization Agent, Logistics Routing Agent, Chatbot Agent |
+| Stockist | Inventory Optimization Agent for reorder alerts, Chatbot Agent for queries, Dashboard Agent for sales charts |
+| Auditor | Invoice Reconciliation Agent for compliance, Logistics Routing Agent for route cost analysis, Dashboard Agent for reports |

--- a/pravichain-scm/dashboards/app.py
+++ b/pravichain-scm/dashboards/app.py
@@ -1,14 +1,85 @@
-"""Dashboard Agent."""
+"""Dashboard Agent with role-based views."""
 
-import dash
-from dash import html
+import pandas as pd
+import plotly.express as px
+from dash import Dash, html, dcc, dash_table
+from dash.dependencies import Input, Output
 
-app = dash.Dash(__name__)
+app = Dash(__name__)
 
-app.layout = html.Div([
-    html.H1('PraviChain SCM Dashboard'),
-    html.P('Placeholder dashboard')
-])
+# Sample data for demo purposes
+sales_df = pd.DataFrame(
+    {
+        "date": pd.date_range("2023-01-01", periods=7),
+        "sales": [100, 120, 90, 130, 150, 170, 160],
+    }
+)
 
-if __name__ == '__main__':
-    app.run_server(debug=True)
+inventory_df = pd.DataFrame(
+    {
+        "sku": ["A", "B", "C"],
+        "stock": [40, 20, 15],
+    }
+)
+
+routes_df = pd.DataFrame(
+    {
+        "route": ["R1", "R2", "R3"],
+        "success_rate": [95, 88, 92],
+    }
+)
+
+roles = [
+    "Super Admin",
+    "Manufacturer",
+    "CFA",
+    "Super Stockist",
+    "Stockist",
+    "Auditor",
+]
+
+app.layout = html.Div(
+    [
+        html.H1("PraviChain SCM Dashboard"),
+        dcc.Dropdown(
+            id="role-dropdown",
+            options=[{"label": r, "value": r} for r in roles],
+            value="Manufacturer",
+            clearable=False,
+        ),
+        html.Div(id="role-content"),
+    ]
+)
+
+
+@app.callback(Output("role-content", "children"), Input("role-dropdown", "value"))
+def render_content(role):
+    """Render role-specific dashboard content."""
+    if role == "Manufacturer":
+        fig = px.line(sales_df, x="date", y="sales", title="Weekly Sales Forecast")
+        return dcc.Graph(figure=fig)
+    if role == "CFA":
+        return dash_table.DataTable(
+            data=inventory_df.to_dict("records"),
+            columns=[{"name": i, "id": i} for i in inventory_df.columns],
+        )
+    if role == "Super Stockist":
+        fig = px.bar(routes_df, x="route", y="success_rate", title="Route Success Rate")
+        return dcc.Graph(figure=fig)
+    if role == "Stockist":
+        fig = px.line(sales_df, x="date", y="sales", title="Sales Overview")
+        return dcc.Graph(figure=fig)
+    if role == "Auditor":
+        return html.P("Audit reports will appear here.")
+    # Super Admin or other roles
+    return html.Ul(
+        [
+            html.Li("Monitor all agents"),
+            html.Li("View analytics"),
+            html.Li("Manage users"),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add new `Role to Agent Matrix` to the agent spec
- implement a role-specific dashboard with placeholder graphs

## Testing
- `python -m py_compile pravichain-scm/dashboards/app.py`
- `python -m py_compile pravichain-scm/agents/*.py pravichain-scm/api/*.py`
- `python pravichain-scm/dashboards/app.py` *(fails if dash packages missing, after installing it runs)*

------
https://chatgpt.com/codex/tasks/task_e_685177e15ba8832ab785fd03bfadc5d3