### PR TITLE
Add local setup helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+*.pyo

--- a/pravichain-scm/api/main.py
+++ b/pravichain-scm/api/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from .forecast_routes import router as forecast_router
+from .inventory_routes import router as inventory_router
+from .chat_routes import router as chat_router
+
+app = FastAPI()
+
+app.include_router(forecast_router)
+app.include_router(inventory_router)
+app.include_router(chat_router)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+pandas
+prophet
+psycopg2-binary
+pulp
+numpy
+fastapi
+uvicorn
+dash
+plotly
+pdfminer.six
+pytesseract
+ortools


### PR DESCRIPTION
## Summary
- add minimal `.gitignore`
- add FastAPI startup entry `api/main.py`
- include empty `__init__` for the API package
- provide initial `requirements.txt`

## Testing
- `python pravichain-scm/agents/forecast.py` *(fails: connection refused)*
- `python pravichain-scm/agents/inventory.py` *(fails: connection refused)*
- `python pravichain-scm/agents/logistics.py` *(fails: connection refused)*
- `bash pravichain-scm/agents/chatbot/llama_runner.sh "Hello"` *(fails: command not found)*
- `python pravichain-scm/dashboards/app.py` *(runs and serves dashboard)*
- `PYTHONPATH=./pravichain-scm uvicorn pravichain-scm.api.main:app --host 127.0.0.1 --port 8000 --workers 1` *(runs API server)*

------
https://chatgpt.com/codex/tasks/task_e_68517b3ddd28832a824bc66c87c46107