### PR TITLE
Add Ubuntu setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ cd dashboards && python app.py
 ollama run deepseek-coder:1.3b
 codex generate agent forecast --inputs sales.csv --output forecast.pkl --model prophet
 ```
+
+## One-step Setup (Ubuntu)
+
+For new Ubuntu systems, run the provided script to install all required packages
+and prepare a local database:
+
+```bash
+bash setup_ubuntu.sh
+```
+
+The script installs system dependencies, creates a Python virtual environment,
+builds `llama.cpp` for the chatbot agent, and sets up a PostgreSQL database
+`scm` with username `user` and password `pass`.

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Enhanced setup script for new Ubuntu systems
+# Installs system dependencies, Python packages, and prepares local environment
+
+# Update package list and upgrade
+sudo apt-get update && sudo apt-get -y upgrade
+
+# Install system packages required by the agents
+sudo apt-get install -y \
+    python3 python3-venv python3-pip \
+    build-essential git \
+    libpq-dev tesseract-ocr \
+    wget curl
+
+# Create Python virtual environment if not present
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+
+# Upgrade pip inside the venv
+pip install --upgrade pip
+
+# Install Python requirements
+pip install -r requirements.txt
+
+# Optional: build llama.cpp for chatbot agent
+if [ ! -d "llama.cpp" ]; then
+    git clone https://github.com/ggerganov/llama.cpp.git
+    (cd llama.cpp && make)
+    sudo ln -sf "$PWD/llama.cpp/main" /usr/local/bin/llama.cpp
+fi
+
+# Install package in editable mode
+pip install -e .
+
+# Create default PostgreSQL user and database
+sudo -u postgres psql <<'SQL'
+CREATE USER "user" WITH PASSWORD 'pass';
+CREATE DATABASE scm OWNER "user";
+SQL
+
+echo "Setup complete. Activate the virtual environment with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add a `setup_ubuntu.sh` script to automate installation on Ubuntu
- document new setup instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n setup_ubuntu.sh`
- `python pravichain-scm/agents/forecast.py` *(fails: connection refused)*
- `python pravichain-scm/agents/inventory.py` *(fails: connection refused)*
- `python pravichain-scm/agents/logistics.py` *(fails: connection refused)*
- `python pravichain-scm/agents/invoice_match.py /workspace/sample_invoice.pdf` *(fails: connection refused)*
- `bash pravichain-scm/agents/chatbot/llama_runner.sh "hello"` *(fails: command not found)*
- `python pravichain-scm/api/main.py` *(fails: attempted relative import)*
- `python pravichain-scm/dashboards/app.py` *(runs until interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_685182d52ca4832ab70e5a60beb8ccbe