### PR TITLE
Add manufacturer admin registration form

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This document outlines the core architecture and operational instructions. For o
   - **🤖 Conversational AI Assistant**: An integrated, offline chatbot for natural language queries about stock and orders.
   - **📊 Interactive Dashboard**: A central UI for visualizing the entire SCM workflow, running what-if scenarios, and generating reports.
   - **🔒 100% Offline & Secure**: All agents run locally. No data ever leaves your premises.
+  - **📝 Manufacturer Admin Registration**: Simple web form at `/register` to create manufacturer admin accounts.
 
 ## 🏛️ System Architecture & Agent Roles
 
@@ -75,7 +76,10 @@ source venv/bin/activate
 # 3. Install all required packages
 pip install -r requirements.txt
 
-# 4. Download required AI models (e.g., the chatbot LLM)
+# 4. Prepare the local SQLite database with sample data
+python scripts/populate_sample_db.py
+
+# 5. Download required AI models (e.g., the chatbot LLM)
 # Ensure the correct .gguf model file is placed in the models/ directory
 ```
 
@@ -117,6 +121,7 @@ The API server exposes agent functionalities over a local network.
 ```bash
 uvicorn api.main:app --host 127.0.0.1 --port 8000
 ```
+Then open `http://127.0.0.1:8000/register` in your browser to create a manufacturer admin account.
 
 ### 3\. Launch the Interactive Dashboard
 

--- a/pravichain-scm/api/auth_routes.py
+++ b/pravichain-scm/api/auth_routes.py
@@ -1,0 +1,49 @@
+"""Authentication and user management routes."""
+from fastapi import APIRouter, Form
+from fastapi.responses import HTMLResponse
+import sqlite3
+
+router = APIRouter()
+
+
+def init_db():
+    conn = sqlite3.connect('db/scm.sqlite')
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE,
+            password TEXT,
+            role TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+init_db()
+
+
+@router.get('/register', response_class=HTMLResponse)
+def register_form():
+    """Return a simple registration form for manufacturer admins."""
+    return """
+    <h2>Create Manufacturer Admin</h2>
+    <form action='/register' method='post'>
+        <input name='username' placeholder='Username' required>
+        <input name='password' placeholder='Password' type='password' required>
+        <button type='submit'>Register</button>
+    </form>
+    """
+
+
+@router.post('/register')
+def register_user(username: str = Form(...), password: str = Form(...)):
+    conn = sqlite3.connect('db/scm.sqlite')
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO users (username, password, role) VALUES (?, ?, 'Manufacturer')",
+        (username, password),
+    )
+    conn.commit()
+    conn.close()
+    return {"status": "user created", "username": username}

--- a/pravichain-scm/api/forecast_routes.py
+++ b/pravichain-scm/api/forecast_routes.py
@@ -1,7 +1,7 @@
 """API routes for demand forecast."""
 
 from fastapi import APIRouter
-from agents.forecast import main as run_forecast
+from pravichain_scm.agents.forecast import main as run_forecast
 
 router = APIRouter()
 

--- a/pravichain-scm/api/inventory_routes.py
+++ b/pravichain-scm/api/inventory_routes.py
@@ -1,7 +1,7 @@
 """API routes for inventory optimization."""
 
 from fastapi import APIRouter
-from agents.inventory import main as run_inventory
+from pravichain_scm.agents.inventory import main as run_inventory
 
 router = APIRouter()
 

--- a/pravichain-scm/api/main.py
+++ b/pravichain-scm/api/main.py
@@ -2,10 +2,12 @@ from fastapi import FastAPI
 from .forecast_routes import router as forecast_router
 from .inventory_routes import router as inventory_router
 from .chat_routes import router as chat_router
+from .auth_routes import router as auth_router
 
 app = FastAPI()
 
 app.include_router(forecast_router)
 app.include_router(inventory_router)
 app.include_router(chat_router)
+app.include_router(auth_router)
 

--- a/pravichain-scm/scripts/populate_sample_db.py
+++ b/pravichain-scm/scripts/populate_sample_db.py
@@ -1,0 +1,45 @@
+import sqlite3
+import pandas as pd
+import os
+
+os.makedirs('db', exist_ok=True)
+conn = sqlite3.connect('db/scm.sqlite')
+
+conn.execute("CREATE TABLE IF NOT EXISTS sales_data (date TEXT, sku TEXT, quantity INTEGER)")
+conn.execute("CREATE TABLE IF NOT EXISTS inventory (sku TEXT, location TEXT, stock INTEGER, lead_time INTEGER)")
+conn.execute("CREATE TABLE IF NOT EXISTS deliveries (id INTEGER PRIMARY KEY, address_lat REAL, address_lon REAL, status TEXT)")
+conn.execute("CREATE TABLE IF NOT EXISTS invoices (id INTEGER PRIMARY KEY, vendor TEXT, amount REAL)")
+
+sales = pd.DataFrame({
+    'date': pd.date_range('2023-01-01', periods=10).astype(str),
+    'sku': ['A'] * 10,
+    'quantity': list(range(10, 20))
+})
+sales.to_sql('sales_data', conn, if_exists='replace', index=False)
+
+inventory = pd.DataFrame({
+    'sku': ['A', 'B'],
+    'location': ['WH1', 'WH2'],
+    'stock': [100, 150],
+    'lead_time': [2, 3]
+})
+inventory.to_sql('inventory', conn, if_exists='replace', index=False)
+
+deliveries = pd.DataFrame({
+    'id': [1, 2],
+    'address_lat': [12.9716, 12.2958],
+    'address_lon': [77.5946, 76.6394],
+    'status': ['pending', 'pending']
+})
+deliveries.to_sql('deliveries', conn, if_exists='replace', index=False)
+
+invoices = pd.DataFrame({
+    'id': [1],
+    'vendor': ['ACME'],
+    'amount': [100.0]
+})
+invoices.to_sql('invoices', conn, if_exists='replace', index=False)
+
+conn.commit()
+conn.close()
+print('Sample database created.')


### PR DESCRIPTION
## Summary
- include new manufacturer admin registration endpoints
- integrate registration into API router
- sample DB population script to test agents
- bullet points in README with instructions
- refactor API route imports

## Testing
- `pip install -r requirements.txt`
- `python pravichain-scm/scripts/populate_sample_db.py`
- `python pravichain-scm/agents/forecast.py`
- `python pravichain-scm/agents/inventory.py`
- `python pravichain-scm/agents/logistics.py`
- `python pravichain-scm/agents/invoice_match.py dummy.pdf` *(fails: No /Root object)*
- `./pravichain-scm/agents/chatbot/llama_runner.sh "hello"` *(fails: command not found)*
- `uvicorn pravichain_scm.api.main:app` then `curl -X POST -F "username=test" -F "password=123" http://127.0.0.1:8000/register`

------
https://chatgpt.com/codex/tasks/task_e_68518aabbe3c832ab3c2ec11b79db919