### PR TITLE
Add automated tests and dashboard updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,12 @@ This is the primary user interface for visualizing data and reports.
 ```bash
 python dashboards/app.py
 ```
+
+### 4\. Run Automated Tests
+
+After installing the requirements you can execute the test suite to verify that
+all agents operate correctly:
+
+```bash
+pytest -q
+```

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+import sqlite3
+from pathlib import Path
+
+from pravichain_scm.agents import forecast, inventory, logistics, invoice_match
+
+DB_PATH = Path("db/scm.sqlite")
+
+
+def setup_module():
+    """Prepare sample data and a test invoice."""
+    subprocess.run(["python", "pravichain-scm/scripts/populate_sample_db.py"], check=True)
+    os.makedirs("uploads", exist_ok=True)
+    from reportlab.pdfgen import canvas
+    c = canvas.Canvas("uploads/invoice_test.pdf")
+    c.drawString(100, 750, "Invoice Vendor: ACME")
+    c.save()
+
+
+def test_forecast():
+    forecast.main()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.execute("select count(*) from forecast")
+    assert cur.fetchone()[0] > 0
+
+
+def test_inventory():
+    inventory.main()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.execute("select count(*) from reorder_plan")
+    assert cur.fetchone()[0] > 0
+
+
+def test_logistics():
+    logistics.main()
+
+
+def test_invoice_match():
+    invoice_match.run("uploads/invoice_test.pdf")


### PR DESCRIPTION
## Summary
- add initial pytest suite to exercise core agents
- show real database data in dashboard if available
- document how to run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851937a1c08832abac7414de875a678